### PR TITLE
BackEnd : Association Error Hotfix

### DIFF
--- a/backend/src/associations.js
+++ b/backend/src/associations.js
@@ -7,7 +7,7 @@ import dosen from '@proyek3/postgres-database/models/Dosen'
 import jabatan from '@proyek3/postgres-database/models/Jabatan'
 import jurusan from '@proyek3/postgres-database/models/Jurusan'
 import jadwal from '@proyek3/postgres-database/models/Jadwal'
-import studi from './models/Studi'
+import studi from '@proyek3/postgres-database/models/Studi'
 
 export const setAssociations = () => {
   programStudi.hasMany(mataKuliah, {


### PR DESCRIPTION
Fixes Association error within backend. Fixed by moving import of studi model to postgres-database version of studi model (and yes there are two, maybe even more? idk).

Closes #11 